### PR TITLE
feat: 회원 좌표 갱신 기능

### DIFF
--- a/src/main/java/com/hanghae/theham/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanghae/theham/domain/member/controller/MemberController.java
@@ -2,18 +2,19 @@ package com.hanghae.theham.domain.member.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hanghae.theham.domain.member.controller.docs.MemberControllerDocs;
+import com.hanghae.theham.domain.member.dto.MemberRequestDto.MemberUpdatePositionRequestDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.GoogleUserInfoDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.KakaoUserInfoDto;
+import com.hanghae.theham.domain.member.dto.MemberResponseDto.MemberUpdatePositionResponseDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.NaverUserInfoDto;
-import com.hanghae.theham.domain.member.service.AuthService;
-import com.hanghae.theham.domain.member.service.GoogleService;
-import com.hanghae.theham.domain.member.service.KakaoService;
-import com.hanghae.theham.domain.member.service.NaverService;
+import com.hanghae.theham.domain.member.service.*;
 import com.hanghae.theham.global.dto.ResponseDto;
+import com.hanghae.theham.global.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -22,12 +23,14 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController implements MemberControllerDocs {
 
     private final AuthService authService;
+    private final MemberService memberService;
     private final KakaoService kakaoService;
     private final GoogleService googleService;
     private final NaverService naverService;
 
-    public MemberController(AuthService authService, KakaoService kakaoService, GoogleService googleService, NaverService naverService) {
+    public MemberController(AuthService authService, MemberService memberService, KakaoService kakaoService, GoogleService googleService, NaverService naverService) {
         this.authService = authService;
+        this.memberService = memberService;
         this.kakaoService = kakaoService;
         this.googleService = googleService;
         this.naverService = naverService;
@@ -49,6 +52,15 @@ public class MemberController implements MemberControllerDocs {
             HttpServletResponse response
     ) {
         authService.logout(request, response);
+    }
+
+    @PatchMapping("/position")
+    public ResponseDto<MemberUpdatePositionResponseDto> updatePosition(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody MemberUpdatePositionRequestDto requestDto
+    ) {
+        MemberUpdatePositionResponseDto responseDto = memberService.updatePosition(userDetails.getUsername(), requestDto);
+        return ResponseDto.success("회원 좌표 갱신 기능", responseDto);
     }
 
     @GetMapping("/kakao/callback")

--- a/src/main/java/com/hanghae/theham/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/hanghae/theham/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,14 +1,18 @@
 package com.hanghae.theham.domain.member.controller.docs;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hanghae.theham.domain.member.dto.MemberRequestDto.MemberUpdatePositionRequestDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.GoogleUserInfoDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.KakaoUserInfoDto;
+import com.hanghae.theham.domain.member.dto.MemberResponseDto.MemberUpdatePositionResponseDto;
 import com.hanghae.theham.domain.member.dto.MemberResponseDto.NaverUserInfoDto;
 import com.hanghae.theham.global.dto.ResponseDto;
+import com.hanghae.theham.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "members", description = "회원 관련 API")
@@ -24,6 +28,12 @@ public interface MemberControllerDocs {
     void logout(
             HttpServletRequest request,
             HttpServletResponse response
+    );
+
+    @Operation(summary = "회원 좌표 갱신 기능", description = "회원 좌표를 갱싱할 수 있는 API")
+    ResponseDto<MemberUpdatePositionResponseDto> updatePosition(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            MemberUpdatePositionRequestDto requestDto
     );
 
     @Operation(summary = "카카오 로그인 기능", description = "카카오 로그인할 수 있는 API")

--- a/src/main/java/com/hanghae/theham/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/hanghae/theham/domain/member/dto/MemberRequestDto.java
@@ -1,4 +1,17 @@
 package com.hanghae.theham.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
 public class MemberRequestDto {
+
+    @Getter
+    public static class MemberUpdatePositionRequestDto {
+
+        @Schema(description = "위도", example = "37.541")
+        private double latitude;
+
+        @Schema(description = "경도", example = "126.986")
+        private double longitude;
+    }
 }

--- a/src/main/java/com/hanghae/theham/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/hanghae/theham/domain/member/dto/MemberResponseDto.java
@@ -1,8 +1,22 @@
 package com.hanghae.theham.domain.member.dto;
 
+import com.hanghae.theham.domain.member.entity.Member;
 import lombok.Getter;
 
 public class MemberResponseDto {
+
+    @Getter
+    public static class MemberUpdatePositionResponseDto {
+        private final Long id;
+        private final double latitude;
+        private final double longitude;
+
+        public MemberUpdatePositionResponseDto(Member member) {
+            this.id = member.getId();
+            this.latitude = member.getLatitude();
+            this.longitude = member.getLongitude();
+        }
+    }
 
     @Getter
     public static class KakaoUserInfoDto {

--- a/src/main/java/com/hanghae/theham/domain/member/entity/Member.java
+++ b/src/main/java/com/hanghae/theham/domain/member/entity/Member.java
@@ -34,6 +34,12 @@ public class Member {
     private RoleType role = RoleType.ROLE_USER;
 
     @Column
+    private double latitude; // 위도
+
+    @Column
+    private double longitude; // 경도
+
+    @Column
     private Long kakaoId;
 
     @Column
@@ -43,12 +49,14 @@ public class Member {
     private String naverId;
 
     @Builder
-    public Member(String email, String password, String nickname, String profileUrl, RoleType role, Long kakaoId, String googleId, String naverId) {
+    public Member(String email, String password, String nickname, String profileUrl, RoleType role, double latitude, double longitude, Long kakaoId, String googleId, String naverId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.role = role;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.kakaoId = kakaoId;
         this.googleId = googleId;
         this.naverId = naverId;
@@ -67,5 +75,10 @@ public class Member {
     public Member naverIdUpdate(String naverId) {
         this.naverId = naverId;
         return this;
+    }
+
+    public void updatePosition(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/src/main/java/com/hanghae/theham/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanghae/theham/domain/member/service/MemberService.java
@@ -1,9 +1,34 @@
 package com.hanghae.theham.domain.member.service;
 
+import com.hanghae.theham.domain.member.dto.MemberRequestDto.MemberUpdatePositionRequestDto;
+import com.hanghae.theham.domain.member.dto.MemberResponseDto.MemberUpdatePositionResponseDto;
+import com.hanghae.theham.domain.member.entity.Member;
+import com.hanghae.theham.domain.member.repository.MemberRepository;
+import com.hanghae.theham.global.exception.BadRequestException;
+import com.hanghae.theham.global.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
+@Transactional(readOnly = true)
 @Service
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public MemberUpdatePositionResponseDto updatePosition(String email, MemberUpdatePositionRequestDto requestDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> {
+            log.error("회원 정보를 찾을 수 없습니다. 이메일: {}", email);
+            return new BadRequestException(ErrorCode.NOT_FOUND_MEMBER.getMessage());
+        });
+
+        member.updatePosition(requestDto.getLatitude(), requestDto.getLongitude());
+        return new MemberUpdatePositionResponseDto(member);
+    }
 }

--- a/src/main/java/com/hanghae/theham/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanghae/theham/global/config/SecurityConfig.java
@@ -59,7 +59,10 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/ping").permitAll()
+
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/members/position").authenticated()
                         .requestMatchers("/api/v1/members/**").permitAll()
+
                         .requestMatchers(HttpMethod.GET, "/api/v1/rentals/{rentalId}").permitAll()
                         .anyRequest().authenticated()
         );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
 spring:
   profiles:
     active: dev
-    include: oauth


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!-- 기입 예 -->
<!-- * #{이슈번호} -->

* #29 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

- 회원 위치 좌표(위도, 경도) 값 갱신 하는 기능을 추가했습니다.
  - 부분 수정이므로 타입은 Patch로 진행 했습니다.

request
```json
{
  "latitude": 37.541,
  "longitude": 126.986
}
```

response
```json
{
  "status": true,
  "message": "회원 좌표 갱신 기능",
  "data": {
    "id": 1,
    "latitude": 1.1,
    "longitude": 2.2
  }
}
```

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

* 게시글에 위도, 경도 값 넣어주기
* 위도, 경도 값 계산해서 범위 내의 게시글 보여주기

## Check List

<!-- 기능 구현을 다 했다면? -->

- [x] 포스트맨으로 체크해 보았나요?