### PR TITLE
fix: 함께쓰기 카테고리 조회시 응답 값 영어로 수정

### DIFF
--- a/src/main/java/com/hanghae/theham/domain/rental/dto/RentalResponseDto.java
+++ b/src/main/java/com/hanghae/theham/domain/rental/dto/RentalResponseDto.java
@@ -2,6 +2,7 @@ package com.hanghae.theham.domain.rental.dto;
 
 import com.hanghae.theham.domain.rental.dto.RentalImageResponseDto.RentalImageReadResponseDto;
 import com.hanghae.theham.domain.rental.entity.Rental;
+import com.hanghae.theham.domain.rental.entity.type.CategoryType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,7 +32,7 @@ public class RentalResponseDto {
         private Long rentalId;
         private String nickname;
         private String profileUrl;
-        private String category;
+        private CategoryType category;
         private String title;
         private String content;
         private long rentalFee;
@@ -44,7 +45,7 @@ public class RentalResponseDto {
             this.rentalId = rental.getId();
             this.nickname = rental.getMember().getNickname();
             this.profileUrl = rental.getMember().getProfileUrl();
-            this.category = rental.getCategory().getValue();
+            this.category = rental.getCategory();
             this.title = rental.getTitle();
             this.content = rental.getContent();
             this.rentalFee = rental.getRentalFee();


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!-- 기입 예 -->
<!-- * #{이슈번호} -->

* #149 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 함께쓰기 카테고리 조회시 영어로 수정

```json
{
  "status": true,
  "message": "함께쓰기 게시글 조회 기능",
  "data": {
    "rentalId": 2,
    "nickname": "더함이004",
    "profileUrl": "https://phinf.pstatic.net/contact/20230707_248/1688656442308bd44W_PNG/11877.png",
    "category": "HOUSEHOLD",
    "title": "**",
    "content": "**",
    "rentalFee": 0,
    "deposit": 0,
    "district": "동대문구",
    "isChatButton": true,
    "rentalImageList": []
  }
}
```

<!-- 기능 구현을 다 했다면? -->

- [x] 포스트맨으로 체크해 보았나요?