### PR TITLE
feat: 채팅방 안읽은 메세지 읽음시 알림 전송

### DIFF
--- a/src/main/java/com/hanghae/theham/domain/notification/dto/type/NotificationType.java
+++ b/src/main/java/com/hanghae/theham/domain/notification/dto/type/NotificationType.java
@@ -4,9 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum NotificationType {
-    CONNECTED("SSE 연결성공"),
-    CHAT("새로운 메세지"),
-    UPDATE_CHATROOM("채팅방 업데이트"),
+    CONNECTED("sse connected"),
+    NEW_CHAT("new chat"),
+    READ_CHATROOM_MESSAGE("read chatRoom message"),
+    UPDATE_CHATROOM("update chatroom"),
     ;
 
     private final String message;


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!-- 기입 예 -->
<!-- * #{이슈번호} -->

* #160 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 채팅방 입장하여 안읽은 메세지 읽음시 메세지 읽음 알림 전송
  * 총 메세지 카운트 수 반환 할 수 있도록 하였습니다. 
    * 이렇게 한 이유 
    * 1. 채팅방 입장하는 걸 front 에서는 유저가 몇번방에 입장하는지 알기 때문에 방 정보를 함께 보내 줄 이유가 없다고 판단. -> 알아서 채팅방 목록에 안읽은 메세지 수 없음 처리 하면 될거라고 판단했습니다.
    * 2. 하지만 전체 메세지 수는 줄어야 한다고 생각하여 위와 같이 안읽은 메세지가 있는 채팅방 입장시 읽음처리후의 총 메세지 수 반환하여 총 메세지 카운트 줄 수 있도록 하였습니다.

**🥔NotificationType.java** 변경 / 프론트 반환시 enum으로 정의된 필드 `name` 이 반환 되도록 하였습니다~
``` java
package com.hanghae.theham.domain.notification.dto.type;

import lombok.Getter;

@Getter
public enum NotificationType {
    CONNECTED("sse connected"),
    NEW_CHAT("new chat"),
    READ_CHATROOM_MESSAGE("read chatRoom message"),
    UPDATE_CHATROOM("update chatroom"),
    ;

    private final String message;

    NotificationType(String message) {
        this.message = message;
    }
}
```

**🥔메세지 읽기 수행 후 sse 이벤트 정상 전송 확인**

``` json
"id": 3_1714357674172
"event": sse
"data": {
"status":true,
"message":"READ_CHATROOM_MESSAGE",
"data":{
"totalUnreadCount":16}
}
```

---

**🥔application-dev.yml 추가사**
``` yml
  jpa:
    open-in-view: false
```
- 저는 먼저 경험하신 선생님들이 계셔서 OSIV 설정을 위와같이 `false`로 변경하여 진행하였습니다. 참고링크 확인 부탁드립니다.


---
참고링크 :
(https://velog.io/@jhbae0420/SSE%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%B1%84%ED%8C%85%EB%B0%A9-%EB%AA%A9%EB%A1%9D-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-%EA%B8%B0%EB%8A%A5%EC%97%90%EC%84%9C-%EB%B0%9C%EC%83%9D%ED%95%9C-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0OSIV)

(https://velog.io/@jhbae0420/SSE%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%B1%84%ED%8C%85%EB%B0%A9-%EB%AA%A9%EB%A1%9D-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-%EA%B8%B0%EB%8A%A5%EC%97%90%EC%84%9C-%EB%B0%9C%EC%83%9D%ED%95%9C-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0OSIV)