### PR TITLE
fix: update 채팅방 정보 항상 메세지 보낸 사람 기준으로 가는 버그 수정

### DIFF
--- a/src/main/java/com/hanghae/theham/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/hanghae/theham/domain/notification/service/NotificationService.java
@@ -65,10 +65,10 @@ public class NotificationService {
     public void sendNotification(ChatRoom chatRoom, boolean isSender, int currentMemberCount) {
         // 채팅방 업데이트가 될 대상 : 채팅방 참여자
         Member sender = chatRoom.getSender();
-        sendChatRoomInformation(sender.getId(), ResponseDto.success(NotificationType.UPDATE_CHATROOM.name(), getChatRoomInfoResponseDto(chatRoom, isSender)));
+        sendChatRoomInformation(sender.getId(), ResponseDto.success(NotificationType.UPDATE_CHATROOM.name(), getChatRoomInfoResponseDto(chatRoom, sender)));
 
         Member receiver = chatRoom.getReceiver();
-        sendChatRoomInformation(receiver.getId(), ResponseDto.success(NotificationType.UPDATE_CHATROOM.name(), getChatRoomInfoResponseDto(chatRoom, isSender)));
+        sendChatRoomInformation(receiver.getId(), ResponseDto.success(NotificationType.UPDATE_CHATROOM.name(), getChatRoomInfoResponseDto(chatRoom, receiver)));
 
         if (currentMemberCount == 1) {
             int totalUnreadCount = getTotalUnreadMessagesCount(isSender ? receiver : sender);
@@ -101,7 +101,8 @@ public class NotificationService {
         );
     }
 
-    private ChatRoomInfoResponseDto getChatRoomInfoResponseDto(ChatRoom chatRoom, boolean isSender) {
+    private ChatRoomInfoResponseDto getChatRoomInfoResponseDto(ChatRoom chatRoom, Member member) {
+        boolean isSender = member.equals(chatRoom.getSender());
         Member toMember = isSender ? chatRoom.getReceiver() : chatRoom.getSender();
         int unreadCount = isSender ? chatRoom.getSenderUnreadCount() : chatRoom.getReceiverUnreadCount();
         return new ChatRoomInfoResponseDto(chatRoom, toMember, unreadCount);


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!-- 기입 예 -->
<!-- * #{이슈번호} -->

* #180 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

- 채팅방 업데이트 정보가 항상 메세지 보낸사람 기준으로 전송되던 버그 수정하였습니다.

**메세지 보낸사람(더함이002) 채팅방 업데이트 정보**
```json
id:2_1714612904927
event:sse
data:{
"status":true,
"message":"UPDATE_CHATROOM",
"data":{
"chatRoomId":15,
"toMemberId":1,
"toMemberNickName":"더함이001",
"toMemberProfileUrl":"http://t1.kakaocdn.net/account_images/default_profile.jpeg.twg.thumb.R640x640",
"lastMessage":"\nd",
"unreadCount":0,
"lastMessageTime":"2024-05-02 10:21:53"}
}
```

**메세지 받는사람(더함이001) 채팅방 업데이트 정보**
```json
id:1_1714612838008
event:sse
data:{
"status":true,
"message":"UPDATE_CHATROOM",
"data":{"chatRoomId":15,
"toMemberId":2,
"toMemberNickName":"더함이002",
"toMemberProfileUrl":"https://phinf.pstatic.net/contact/20230710_264/1688989560819Fk7XC_PNG/Profile_defaultIMG_R2x.png","lastMessage":"\nd",
"unreadCount":19,
"lastMessageTime":"2024-05-02 10:21:53"}}

id:1_1714612838008
event:sse
data:{"status":true,"message":"new chat","data":{"totalUnreadCount":96}}
```